### PR TITLE
Limit NchanNear to actual number of channels.

### DIFF
--- a/clustering/extract_spikes.m
+++ b/clustering/extract_spikes.m
@@ -41,7 +41,7 @@ dNearActiveSite = median(diff(unique(rez.yc)));
 NrankPC = 6;
 [wTEMP, wPCA]    = extractTemplatesfromSnippets(rez, NrankPC);
 
-NchanNear = 8;
+NchanNear = min(ops.Nchan, 8);
 [iC, dist] = getClosestChannels2(ycup, xcup, rez.yc, rez.xc, NchanNear);
 
 igood = dist(1,:)<dNearActiveSite;

--- a/preProcess/standalone_detector.m
+++ b/preProcess/standalone_detector.m
@@ -22,7 +22,7 @@ wPCA = gpuArray(rez.wPCA);
 
 % Get nearest channels for every template center. 
 % Template products will only be computed on these channels. 
-NchanNear = 10;
+NchanNear = min(ops.Nchan, 10);
 [iC, dist] = getClosestChannels2(ycup, xcup, rez.yc, rez.xc, NchanNear);
 
 % Templates with centers that are far from an active site are discarded


### PR DESCRIPTION
This PR is a marker to flag small changes to the [Kilosort](https://github.com/MouseLand/Kilosort) 3 code base.  I don't expect it to be useful upstream because the upstream repo is already 2 years old, and Kilosort 4 is, I think, on the way.

In the meantime while we're still using Kilosort 3, we found that it won't sort when the number of channels is small.  This is due to some hard coded values like `NchanNear = 10`, and seems to be a known issue:
 - https://github.com/MouseLand/Kilosort/issues/350
 - https://github.com/MouseLand/Kilosort/issues/315
 - https://github.com/MouseLand/Kilosort/issues/285

For whatever reason, the fixes discussed in those issues seem not to be present in Kilosort 3.  So here they are, in this branch.