### PR TITLE
Retry two GPU operations.

### DIFF
--- a/clustering/extract_spikes.m
+++ b/clustering/extract_spikes.m
@@ -94,7 +94,20 @@ for k = 1:ops.Nbatch
     toff = ops.nt0min + t0 + ops.NT *(k-1);
     st(1,:) = st(1,:) + toff;
     st = double(st);
-    st(5,:) = cF;
+    % st(5,:) = cF;
+    % This assignment on line 97 somtimes errors -- I'm not sure why.
+    % Some issue posters reported success with retrying as a workaround.
+    fprintf('extract_spikes size of st:\n');
+    disp(size(st))
+    fprintf('extract_spikes size of cF:\n');
+    disp(size(cF))
+    try
+        st(5,:) = cF;
+    catch e
+        fprintf('extract_spikes retrying after error:\n');
+        disp(e)
+        st(5,:) = cF;
+    end
     st(6,:) = k-1;
     
     st3(nsp + [1:ns], :) = gather(st)';    

--- a/clustering/template_learning.m
+++ b/clustering/template_learning.m
@@ -68,7 +68,20 @@ for j = 1:numel(ycenter)
 %     size(data)
     
     
-    ich = unique(iC(:, itemp));
+    % ich = unique(iC(:, itemp));
+    % This assignment on line 71 somtimes errors -- I'm not sure why.
+    % Some issue posters reported success with retrying as a workaround.
+    fprintf('template_learning size of iC:\n');
+    disp(size(iC))
+    fprintf('template_learning size of itemp:\n');
+    disp(size(itemp))
+    try
+        ich = unique(iC(:, itemp));
+    catch e
+        fprintf('template_learning retrying after error:\n');
+        disp(e)
+        ich = unique(iC(:, itemp));
+    end
 %     ch_min = ich(1)-1;
 %     ch_max = ich(end);
     


### PR DESCRIPTION
This PR is a marker to flag small changes to the [Kilosort](https://github.com/MouseLand/Kilosort) 3 code base. I don't expect it to be useful upstream because the upstream repo is already 2 years old, and Kilosort 4 is, I think, on the way.

In the meantime while we're still using Kilosort 3, we found that on some data sets, a couple of GPU operations throw an error.  This seems to be a known issue.  Some posters have reported success with a workaround -- simply catching the error and retrying those operations.  This adds the try/catch and additional logging, in case that yields some insight.

 - https://github.com/MouseLand/Kilosort/issues/316
 - https://github.com/MouseLand/Kilosort/issues/383
 - https://github.com/MouseLand/Kilosort/issues/384
 - https://github.com/MouseLand/Kilosort/issues/475
 - https://github.com/MouseLand/Kilosort/issues/427

I'm unclear on why this happens, why the try/catch/retry might help -- maybe a race condition with the GPU interactions?  I'm also unclear from the issues whether multiple separate issues are leading to errors on the same lines.  But if this works, we can move on.